### PR TITLE
Allow external configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.js
+custom.css

--- a/index.html
+++ b/index.html
@@ -347,6 +347,8 @@
   }
 </style>
 
+<link rel="stylesheet" href="custom.css">
+
 <div class="center">
   <time id="clock"></time>
 </div>

--- a/index.html
+++ b/index.html
@@ -1,8 +1,9 @@
 <!doctype html>
 
-<script>
-  const CONFIG = {
+<script src="config.js"></script>
 
+<script>
+  const CONFIG = window.CONFIG || {
     // the category, name, key, url, search path and color for your commands
     // if none of the specified keys are matched, the '*' key is used
     commands: [


### PR DESCRIPTION
This adds the ability to have a custom config.js file and custom.css file.

I made a bunch of changes to my config, and I wanted to pull your most recent changes, and I accidentally lost my old config. Sad day -- have to reconfigure. =(

Would love it if I could keep the git changes clean while having my own config.

This will throw a little inconsequential error in the console if the config files don't exist, but there are no breaking changes. I could probably make it check for the script's existence first, but it seems like a pretty unnecessary use of time.

It's also blocking, which means it technically slows the page down extremely slightly, so it might be worth considering making `CONFIG` a thunk or something so we can load the config file at the end/asynchronously.