### PR TITLE
bugfix

### DIFF
--- a/index.html
+++ b/index.html
@@ -1049,6 +1049,7 @@
     }
 
     parse(query) {
+      if (!query) return {};
       if (this._lastQuery === query) {
             return this._lastParse;
         }


### PR DESCRIPTION
Uncaught TypeError: Cannot destructure property `query` of 'undefined' or 'null'. line 791