### PR TITLE
fixed localhost search query

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,8 @@
       {
         key: '0',
         name: 'Local',
-        url: 'http://localhost:3000',
+        search: ':{}',
+        url: 'http://localhost',
       },
     ].map((command) => {
       const hsla = (hue, saturation = 'var(--command-color-saturation)') =>


### PR DESCRIPTION
The localhost option was hardcoded to go to http://localhost:3000 making the default search queries useless. 

Removed the hardcoded url and added a search query.